### PR TITLE
Add Docker configuration for full-stack application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Version control
+.git
+.gitignore
+
+# Node.js dependencies
+front-end/node_modules
+front-end/dist
+
+# Maven build directory
+target/
+
+# IDE files
+.idea/
+*.iml
+.vscode/
+
+# Logs
+*.log
+
+# Environment files
+.env
+*.env.local
+
+# Test files
+*/test/
+*/tests/
+*.spec.ts
+
+# Documentation
+*.md
+docs/
+
+# Docker files
+Dockerfile*
+docker-compose*
+.docker/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM maven:3.8.4-openjdk-17-slim AS build
+
+WORKDIR /app
+
+# Copy pom.xml and download dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline
+
+# Copy source code
+COPY src ./src
+
+# Build the application
+RUN mvn clean package -DskipTests
+
+# Production stage
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+# Copy the built artifact from build stage
+COPY --from=build /app/target/*.jar app.jar
+
+# Environment variables
+ENV SPRING_PROFILES_ACTIVE=prod
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./front-end
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"
+    depends_on:
+      - backend
+    networks:
+      - app-network
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/city_transport
+      - SPRING_DATASOURCE_USERNAME=root
+      - SPRING_DATASOURCE_PASSWORD=root
+    depends_on:
+      - db
+    networks:
+      - app-network
+
+  db:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_DATABASE=city_transport
+      - MYSQL_ROOT_PASSWORD=root
+    volumes:
+      - mysql_data:/var/lib/mysql
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  mysql_data:

--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -1,0 +1,29 @@
+# Build stage
+FROM node:16-alpine as builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy source files
+COPY . .
+
+# Build the application
+RUN npm run build --configuration=production
+
+# Production stage
+FROM nginx:alpine
+
+# Copy built assets from builder stage
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/front-end/nginx.conf
+++ b/front-end/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Support for Angular routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Proxy configuration for backend API
+    location /api/ {
+        proxy_pass http://backend:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,13 @@
+-- Create database if not exists
+CREATE DATABASE IF NOT EXISTS city_transport;
+USE city_transport;
+
+-- Add any initial SQL commands here
+-- You can add your table creation scripts and initial data here
+
+-- Example:
+-- CREATE TABLE IF NOT EXISTS users (
+--     id BIGINT PRIMARY KEY AUTO_INCREMENT,
+--     username VARCHAR(255) NOT NULL,
+--     password VARCHAR(255) NOT NULL
+-- );

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,23 @@
+# Database Configuration
+spring.datasource.url=jdbc:mysql://db:3306/city_transport
+spring.datasource.username=root
+spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# JPA Configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+# Server Configuration
+server.port=8080
+server.servlet.context-path=/api
+
+# Logging Configuration
+logging.level.root=INFO
+logging.level.com.epam.training=INFO
+
+# CORS Configuration
+spring.mvc.cors.allowed-origins=*
+spring.mvc.cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS
+spring.mvc.cors.allowed-headers=*


### PR DESCRIPTION
This PR adds Docker configuration to run the entire application stack using Docker Compose.

Changes included:
1. Frontend Dockerfile with multi-stage build
2. Backend Dockerfile with multi-stage build
3. Docker Compose configuration
4. Nginx configuration for frontend
5. Production properties for backend
6. MySQL initialization script
7. .dockerignore file

To run the application:
```bash
# Build and start all services
docker-compose up --build

# Access the applications:
Frontend: http://localhost
Backend: http://localhost:8080
Database: localhost:3306
```

Environment variables are configured for:
- MySQL database connection
- Spring Boot production profile
- CORS settings

The setup includes:
- Multi-stage builds for optimized images
- Volume persistence for MySQL data
- Network isolation between services
- Proper dependency management
- Production-ready configurations

Testing Instructions:
1. Install Docker and Docker Compose
2. Clone the repository
3. Run `docker-compose up --build`
4. Access the frontend at http://localhost
5. Verify API calls to backend at http://localhost:8080

Please review the configurations and test the setup before merging.