### PR TITLE
Add OpenAPI property definition

### DIFF
--- a/api/definitions/property_definition.yml
+++ b/api/definitions/property_definition.yml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: Property Definition
+  version: 1.0.0
+
+components:
+  schemas:
+    PropertyObject:
+      type: object
+      properties:
+        prop1:
+          type: array
+          items:
+            type: string
+          description: An array of strings
+          example: ["value1"]
+      required:
+        - prop1


### PR DESCRIPTION
This PR adds an OpenAPI YAML definition for an object with the following structure:
```json
{
  "prop1": ["value1"]
}
```

The definition includes:
- Object schema with a single property "prop1"
- Array type definition for "prop1" with string items
- Example value
- Required field specification