### PR TITLE
Add HashMap support for route creation

### DIFF
--- a/front-end/src/component/pages/route/route.component.html
+++ b/front-end/src/component/pages/route/route.component.html
@@ -28,9 +28,12 @@
     </div>
   </div>-->
 
+<button mat-button (click)="createRouteWithHashMap()">
+    Create Route Using HashMap
+</button>
 
-  <mat-chip-list *ngFor="let route of routes" class="mat-chip-list-stacked">
+<mat-chip-list *ngFor="let route of routes" class="mat-chip-list-stacked">
     <mat-chip  selected="true" color="primary">
       {{route.number}}
     </mat-chip>
-  </mat-chip-list>
+</mat-chip-list>

--- a/front-end/src/component/pages/route/route.component.ts
+++ b/front-end/src/component/pages/route/route.component.ts
@@ -4,6 +4,7 @@ import {RouteList} from "../../../utils/route-list";
 import {Router} from "@angular/router";
 import {RouteEntity} from "../../../model/route/route-entity";
 import {RouteService} from "../../../service/route-service/route.service";
+import { RouteHashMapModel } from '../../../model/route/route-hashmap.model';
 
 @Component({
   selector: 'app-route',
@@ -12,15 +13,11 @@ import {RouteService} from "../../../service/route-service/route.service";
 })
 export class RouteComponent extends PageComponent {
 
-
-
   private _routeInfo: RouteEntity;
 
   private _error: string;
 
-
   private _routes: RouteEntity[];
-
 
   constructor(private readonly routeService: RouteService,
               private readonly router: Router) {
@@ -37,7 +34,6 @@ export class RouteComponent extends PageComponent {
       .then(value => this._routes = value);
   }
 
-
   tryDeletePoint() {
     this.routeService.deleteRoute(this._routeInfo, (message, result) => {
       if (result) {
@@ -52,10 +48,8 @@ export class RouteComponent extends PageComponent {
   }
 
   public tryUpdatePoint() {
-
     this.routeService.updateRoute(this._routeInfo, (message, result) => {
         if (result) {
-
           this.routeService.loadRoutes()
         }
         else {
@@ -64,6 +58,25 @@ export class RouteComponent extends PageComponent {
           this.tryLoadRoutes();
       }
     )
+  }
+
+  public createRouteWithHashMap(): void {
+    const routeData: RouteHashMapModel = {
+        properties: {
+            'number': '123',
+            'description': 'Route created with HashMap'
+        }
+    };
+    
+    this.routeService.createRouteFromHashMap(routeData, (message, result) => {
+        if (result) {
+            this.routeService.loadRoutes();
+            this.ngOnInit();
+        } else {
+            this._error = message;
+        }
+        this.tryLoadRoutes();
+    });
   }
 
   public redirectToRoutes() {
@@ -84,7 +97,6 @@ export class RouteComponent extends PageComponent {
   set error(value: string) {
     this._error = value;
   }
-
 
   get routeInfo(): RouteEntity {
     return this._routeInfo;

--- a/front-end/src/model/route/route-hashmap.model.ts
+++ b/front-end/src/model/route/route-hashmap.model.ts
@@ -1,0 +1,3 @@
+export interface RouteHashMapModel {
+    properties: { [key: string]: string };
+}

--- a/front-end/src/service/route-service/route.service.ts
+++ b/front-end/src/service/route-service/route.service.ts
@@ -5,6 +5,7 @@ import {PointEntity} from "../../model/point/poit-entity";
 import {Utils} from "../../utils/utils";
 import {RouteParams} from "../../model/route/route-params";
 import {RouteEntity} from "../../model/route/route-entity";
+import { RouteHashMapModel } from '../../model/route/route-hashmap.model';
 
 @Injectable()
 export class RouteService {
@@ -26,6 +27,13 @@ export class RouteService {
 
   public createRoute(params: RouteParams, handler: (message: string, result: boolean) => void): void {
     this.http.post(RouteService.PAGE_ROUTES_URL, params)
+      .toPromise()
+      .then(response => handler(null, true))
+      .catch(error => Utils.handleErrorMessageJson(error, (ex: string) => handler(ex, false)));
+  }
+
+  public createRouteFromHashMap(params: RouteHashMapModel, handler: (message: string, result: boolean) => void): void {
+    this.http.post(RouteService.PAGE_ROUTES_URL + '/hashmap', params)
       .toPromise()
       .then(response => handler(null, true))
       .catch(error => Utils.handleErrorMessageJson(error, (ex: string) => handler(ex, false)));

--- a/src/main/java/com/epam/training/transport/rest/controller/RouteController.java
+++ b/src/main/java/com/epam/training/transport/rest/controller/RouteController.java
@@ -23,6 +23,7 @@ import com.epam.training.transport.model.db.entity.RouteEntity;
 import com.epam.training.transport.model.db.entity.RoutePointEntity;
 import com.epam.training.transport.rest.models.AddPointModel;
 import com.epam.training.transport.rest.models.RouteModel;
+import com.epam.training.transport.rest.models.RouteHashMapModel;
 import com.epam.training.transport.service.PointService;
 import com.epam.training.transport.service.RouteService;
 import com.epam.training.transport.utils.validators.RouteModelValidator;
@@ -58,8 +59,16 @@ public class RouteController extends AbstractController {
     @ApiOperation("Create new route")
     @ResponseBody
     public RouteEntity create(@RequestBody RouteModel routeModel) {
-
         return routeService.create(routeModel.getNumber(), routeModel.getDescription());
+    }
+
+    @PostMapping("/hashmap")
+    @ApiOperation("Create new route from hashmap")
+    @ResponseBody
+    public RouteEntity createFromHashMap(@RequestBody RouteHashMapModel model) {
+        String number = model.getProperties().get("number");
+        String description = model.getProperties().get("description");
+        return routeService.create(number, description);
     }
 
     @PutMapping(value = "{routeId}/points/{pointId}")
@@ -69,7 +78,6 @@ public class RouteController extends AbstractController {
     final long routeId, @PathVariable
     final long pointId, @RequestParam
     final int sequence) {
-
         return routeService.insertPoint(routeId, pointId, sequence);
     }
 
@@ -79,7 +87,6 @@ public class RouteController extends AbstractController {
     public RouteEntity insertPoints(@PathVariable
     final long routeId, @RequestBody
     final List<AddPointModel> points) {
-
         return routeService.insertPoints(routeId, points);
     }
 
@@ -90,7 +97,6 @@ public class RouteController extends AbstractController {
     final long routeId, @PathVariable
     final long pointId) {
         return routeService.addPoint(routeId, pointId);
-
     }
 
     @PutMapping("/{id}")
@@ -147,7 +153,6 @@ public class RouteController extends AbstractController {
     @ResponseBody
     public List<RoutePointEntity> loadAllPoints(@PathVariable
     final long routeId) {
-
         return routeService.loadPoints(routeId);
     }
 }

--- a/src/main/java/com/epam/training/transport/rest/models/RouteHashMapModel.java
+++ b/src/main/java/com/epam/training/transport/rest/models/RouteHashMapModel.java
@@ -1,0 +1,23 @@
+package com.epam.training.transport.rest.models;
+
+import java.util.HashMap;
+
+public class RouteHashMapModel {
+    private HashMap<String, String> properties;
+    
+    public RouteHashMapModel() {
+        this.properties = new HashMap<>();
+    }
+    
+    public RouteHashMapModel(HashMap<String, String> properties) {
+        this.properties = properties;
+    }
+    
+    public HashMap<String, String> getProperties() {
+        return properties;
+    }
+    
+    public void setProperties(HashMap<String, String> properties) {
+        this.properties = properties;
+    }
+}


### PR DESCRIPTION
This PR adds support for creating routes using HashMap:

1. Added new `RouteHashMapModel` in both Java and TypeScript
2. Added new endpoint `/api/routes/hashmap` for HashMap-based route creation
3. Added frontend support for HashMap route creation
4. Updated route component with HashMap creation functionality

The changes allow creating routes by passing properties as a HashMap instead of individual fields.